### PR TITLE
Adjust extraParseString two year date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ SmartDateField({maxFutureYears: 20})
 
 The maxFutureYears option specifies the maximum number of years into the future a date can be from the current year before it's automatically adjusted. For example, if maxFutureYears is set to 20, any date that results in a year more than 20 years ahead of the current year will be adjusted to be 100 years in the past.
 
-THe maxFutureYears default is 10 years.
+The maxFutureYears default is 10 years.
 
 ## Supported date formats
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ SmartDateField({extraParseString:"yyyyMMdd"})
 
 Will try to parse all incoming dates normally, if it still can't parse the date, it will try to parse with the parse string. so for the above configured field, the string `'20080302'` parses to `new Date('2008-03-02T00:00:00.000Z')`
 
+
+## Using `maxFutureYears`
+
+In certain situations, parsed dates may inadvertently be set far into the future due to the nature of date parsing, where the year of the date being parsed is ambiguously ahead of the current year. The `maxFutureYears` option allows for limiting how far into the future a date can be parsed before being considered too speculative and adjusted accordingly.
+
+### Configuration Example
+
+```javascript
+SmartDateField({maxFutureYears: 20})
+
+```
+
+The maxFutureYears option specifies the maximum number of years into the future a date can be from the current year before it's automatically adjusted. For example, if maxFutureYears is set to 20, any date that results in a year more than 20 years ahead of the current year will be adjusted to be 100 years in the past.
+
+THe maxFutureYears default is 10 years.
+
 ## Supported date formats
 
 SmartDateField will parse the following formats with no configuration out of the box.

--- a/src/SmartDateField.spec.ts
+++ b/src/SmartDateField.spec.ts
@@ -471,7 +471,13 @@ describe('Cast Function tests ->', () => {
       new Date('2008-03-02T00:00:00.000Z')
     )
   })
-  test('two year date parsing defaults to previous century if date would be more than 10 years out ', () => {
+  test('maxFutureYears', () => {
+    const df = SmartDateField({ extraParseString: 'MMddyy', maxFutureYears: 100 })
+    expect(df.options.cast('010160')).toStrictEqual(
+      new Date('2060-01-01T00:00:00.000Z')
+    )
+  })
+  test('maxFutureYears defaults to ten years out', () => {
     const df = SmartDateField({ extraParseString: 'MMddyy' })
     expect(df.options.cast('010160')).toStrictEqual(
       new Date('1960-01-01T00:00:00.000Z')

--- a/src/SmartDateField.spec.ts
+++ b/src/SmartDateField.spec.ts
@@ -471,4 +471,10 @@ describe('Cast Function tests ->', () => {
       new Date('2008-03-02T00:00:00.000Z')
     )
   })
+  test('two year date parsing defaults to previous century if date would be more than 10 years out ', () => {
+    const df = SmartDateField({ extraParseString: 'MMddyy' })
+    expect(df.options.cast('010160')).toStrictEqual(
+      new Date('1960-01-01T00:00:00.000Z')
+    )
+  })
 })

--- a/src/SmartDateField.ts
+++ b/src/SmartDateField.ts
@@ -128,18 +128,19 @@ const egressDebug = (field: Field<any>, castVal: any) => {
 
 export const SmartDateField = makeField<
   Date,
-  { formatString?: string; extraParseString?: string; locale?: Locales }
+  { formatString?: string; extraParseString?: string; locale?: Locales; maxFutureYears?: number }
 >(DateField({}), {}, (mergedOpts, passedOptions) => {
   const defaultedPassedOptions = {
     ...{
       formatString: "yyyy-MM-dd'T'HH:mm'Z'",
       extraParseString: undefined,
       locale: 'en',
+      maxFutureYears: 10,
     },
     ...passedOptions,
   }
 
-  const { formatString, extraParseString, locale } = defaultedPassedOptions
+  const { formatString, extraParseString, locale, maxFutureYears } = defaultedPassedOptions
 
   if (_.keys(passedOptions).includes('cast')) {
     throw new Error(
@@ -163,7 +164,7 @@ export const SmartDateField = makeField<
         if (typeof val === 'string') {
           let parsed = parse(val, extraParseString, new Date())
           const currentYear = new Date().getFullYear()
-          if (parsed.getFullYear() > currentYear + 10) {
+          if (parsed.getFullYear() > currentYear + maxFutureYears) {
             parsed.setFullYear(parsed.getFullYear() - 100)
           }
           const reformatted = format(parsed, 'yyyy-MM-dd')

--- a/src/SmartDateField.ts
+++ b/src/SmartDateField.ts
@@ -161,7 +161,11 @@ export const SmartDateField = makeField<
       localeCast,
       StringChainCast((val: string | Date): Nullable<Date> => {
         if (typeof val === 'string') {
-          const parsed = parse(val, extraParseString, new Date())
+          let parsed = parse(val, extraParseString, new Date())
+          const currentYear = new Date().getFullYear()
+          if (parsed.getFullYear() > currentYear + 10) {
+            parsed.setFullYear(parsed.getFullYear() - 100)
+          }
           const reformatted = format(parsed, 'yyyy-MM-dd')
           const final = ChronoDateCast(reformatted)
           return final


### PR DESCRIPTION
Adds configurable option to SmartDateField to adjust how two year date parsing works.

Resolves: https://github.com/FlatFilers/support-triage/issues/1108